### PR TITLE
Add keyword support from CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ W pliku CSV możesz uzupełnić:
 * Title - lista tytułów, dla których teksty mają być napisane, każdy tytuł podaj w osobnym wierszu. Lista tytułów wystarczy żeby narzędzie działało poprawnie, pozostałe kolumny są opcjonalne. Nie ma limitu jeżeli chodzi o liczbę tekstów, ogranicza Cię jedynie $ w OpenAI.
 
 * Headings - jeżeli chcesz żeby tekst był napisany według konkretnych nagłówków to możesz podać je w tej kolumnie. Każdy nagłówek powinien być podany w nowej linii. Musisz pamiętać o tym, że jeżeli tekst jest pisany według nagłówków to każdy nagłówek jest osobnym tekstem, a nie kontynuacją poprzednich akapitów.
+* Keywords - lista słów kluczowych, pod które tekst ma być zoptymalizowany. Słowa kluczowe oddziel przecinkami lub nową linią.
 
 * Image search query - jeżeli chcesz żebyss do wpisu zostało dodane zdjęcie to możesz podać frazę, która posłuży do znalezienia zdjęcia na pixabay. Czyli jeżeli wpiszesz tam “office” to jako zdjęcie zostanie wybrany losowy obraz z [https://pixabay.com/images/search/office/](https://pixabay.com/images/search/office/)
 

--- a/data.csv
+++ b/data.csv
@@ -1,6 +1,6 @@
-Title,Headings,Image search query,Categories,Tags,PublishDate
-Przekierowanie 301,,programming,,,2023-12-31T12:00:00
+Title,Headings,Keywords,Image search query,Categories,Tags,PublishDate
+Przekierowanie 301,,przekierowanie 301,programming,,,2023-12-31T12:00:00
 Przekierowanie 302,"Czym jest przekierowanie 302?
 Czym różni się przekierowanie 302 od 301?
 Kiedy stosować przekierowanie 302?
-W jaki sposób ustawić przekierowanie 302 w pliku .htaccess?",programming,,2024-01-05T08:30:00
+W jaki sposób ustawić przekierowanie 302 w pliku .htaccess?","przekierowanie 302, http status 302",programming,,2024-01-05T08:30:00

--- a/index.js
+++ b/index.js
@@ -7,11 +7,14 @@ const mainFunction = async (post, summary, options) => {
   const { wordpress } = options;
   const image = post["Image search query"] == "" ? false : true;
   const headings = post["Headings"].split("\n");
+  const keywords = post["Keywords"]
+    ? post["Keywords"].split(/[,\n]/).map((k) => k.trim()).filter(Boolean)
+    : [];
   const publishDate = post["PublishDate"] || null;
   const content =
     headings[0] !== ""
-      ? await contentWithHeadings(post["Title"], headings)
-      : await createContent(post["Title"]);
+      ? await contentWithHeadings(post["Title"], headings, keywords)
+      : await createContent(post["Title"], false, keywords);
   if (content.error) {
     console.log(content.statusText);
     summary.push({

--- a/openai.js
+++ b/openai.js
@@ -1,7 +1,7 @@
 import { Configuration, OpenAIApi } from "openai";
 import { keys } from "./keys.js";
 
-const createContent = async (title, headings = false) => {
+const createContent = async (title, headings = false, keywords = []) => {
   if (!headings) {
     console.log(`piszę: ${title}`);
   }
@@ -10,9 +10,12 @@ const createContent = async (title, headings = false) => {
     apiKey: keys.AI_KEY,
   });
   const openai = new OpenAIApi(configuration);
+  const kw = keywords.length ? ` Słowa kluczowe: ${keywords.join(", ")}.` : "";
   const prompt = headings
-    ? `Napisz dwa akapity na temat "${title}".`
-    : `Napisz zoptymalizowany pod SEO artykuł blogowy na temat "${title}". Tekst powinien zawierać 3 nagłówki, dla każdego nagłówka napisz 2 akapity. Tekst ma być sformatowany do HTML, nagłówki umieść w <h2>, a akapity w <p>`;
+    ? `Napisz dwa akapity na temat "${title}".` + kw
+    : `Napisz zoptymalizowany pod SEO artykuł blogowy na temat "${title}".` +
+      ` Tekst powinien zawierać 3 nagłówki, dla każdego nagłówka napisz 2 akapity.` +
+      ` Tekst ma być sformatowany do HTML, nagłówki umieść w <h2>, a akapity w <p>.` + kw;
   let failedRequests = 0;
   const maxFails = 4;
   const retry = async (ms) =>
@@ -53,10 +56,10 @@ const createContent = async (title, headings = false) => {
   return response;
 };
 
-const contentWithHeadings = async (title, headings) => {
+const contentWithHeadings = async (title, headings, keywords = []) => {
   console.log(`piszę: ${title}`);
 
-  const arr = headings.map((item) => createContent(item, true));
+  const arr = headings.map((item) => createContent(item, true, keywords));
   const formatText = (item) => {
     return item
       .split("\n")


### PR DESCRIPTION
## Summary
- include `Keywords` column in `data.csv`
- read keywords from CSV and pass them to OpenAI generator
- allow heading-based content creation to use keywords
- update README with new CSV column usage

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841ff635f7c832eb1c0b3eaecc22b02